### PR TITLE
Fix to intermittent Crop resize issue

### DIFF
--- a/php_image_magician.php
+++ b/php_image_magician.php
@@ -750,8 +750,8 @@ class imageLib
       $optimalRatio = $widthRatio;
     }
 
-    $optimalHeight = $this->height / $optimalRatio;
-    $optimalWidth  = $this->width  / $optimalRatio;
+    $optimalHeight = round( $this->height / $optimalRatio );
+    $optimalWidth  = round( $this->width  / $optimalRatio );
 
     return array('optimalWidth' => $optimalWidth, 'optimalHeight' => $optimalHeight);
   }


### PR DESCRIPTION
Patches a bug in the Image Magician library which could cause the _crop_ resize option fail for some images resizing to specific sizes.

Images affected by this bug would be resized to _optimumWidth_ / _Height_, but comparisons on optimum vs new would then fail and the crop wouldn't take place.

Simply rounding the _optimum_ values in the _getOptimalCrop_ method fixes this issue.
