### PR TITLE
Large Images could eat up RAM on reset

### DIFF
--- a/php_image_magician.php
+++ b/php_image_magician.php
@@ -2399,6 +2399,10 @@ class imageLib
     # Notes:
     #
     {
+        $this->__destruct();
+        $this->image = null;
+        $this->imageResized = null;
+        gc_collect_cycles();
         $this->__construct($this->fileName);
     }
 


### PR DESCRIPTION
Large Images eat up 3x its space in RAM while reseting.

This little fix frees the resources that will be reinizialised in construction